### PR TITLE
Descaling: Disable the scala plugin when no scala files are present, improve Eclipse Jabel support

### DIFF
--- a/src/main/java/com/gtnewhorizons/gtnhgradle/GTNHGradlePlugin.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/GTNHGradlePlugin.java
@@ -14,6 +14,7 @@ import com.gtnewhorizons.gtnhgradle.modules.MixinModule;
 import com.gtnewhorizons.gtnhgradle.modules.ModernJavaModule;
 import com.gtnewhorizons.gtnhgradle.modules.OldGradleEmulationModule;
 import com.gtnewhorizons.gtnhgradle.modules.PublishingModule;
+import com.gtnewhorizons.gtnhgradle.modules.ScalaModule;
 import com.gtnewhorizons.gtnhgradle.modules.ShadowModule;
 import com.gtnewhorizons.gtnhgradle.modules.StandardScriptsModules;
 import com.gtnewhorizons.gtnhgradle.modules.StructureCheckModule;
@@ -35,14 +36,11 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.plugins.JavaLibraryPlugin;
 import org.gradle.api.plugins.PluginManager;
-import org.gradle.api.plugins.scala.ScalaPlugin;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin;
-import org.gradle.plugins.ide.eclipse.EclipsePlugin;
 import org.gradle.process.ExecOperations;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.gradle.ext.IdeaExtPlugin;
 
 import javax.inject.Inject;
 import java.util.List;
@@ -70,9 +68,6 @@ public class GTNHGradlePlugin implements Plugin<Project> {
 
         // Apply shared plugins used by all mods
         plugins.apply(JavaLibraryPlugin.class);
-        plugins.apply(IdeaExtPlugin.class);
-        plugins.apply(EclipsePlugin.class);
-        plugins.apply(ScalaPlugin.class);
         plugins.apply(MavenPublishPlugin.class);
         plugins.apply(GrgitPlugin.class);
         plugins.apply(DownloadTaskPlugin.class);
@@ -108,6 +103,7 @@ public class GTNHGradlePlugin implements Plugin<Project> {
             GitVersionModule.class,
             CodeStyleModule.class,
             ToolchainModule.class,
+            ScalaModule.class,
             StructureCheckModule.class,
             AccessTransformerModule.class,
             ShadowModule.class,

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/PropertiesConfiguration.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/PropertiesConfiguration.java
@@ -90,8 +90,18 @@ public final class PropertiesConfiguration {
         preferPopulated = false,
         required = false,
         hidden = true,
-        docComment = "Sets up the Java/Scala/Kotlin toolchain for mod compilation.")
+        docComment = "Sets up the Java/Kotlin toolchain for mod compilation.")
     public boolean moduleToolchain = true;
+
+    /** See annotation */
+    @Prop(
+        name = "gtnh.modules.scala",
+        isSettings = false,
+        preferPopulated = false,
+        required = false,
+        hidden = true,
+        docComment = "Sets up the Scala toolchain for mod compilation if src/main/scala is present.")
+    public boolean scalaToolchain = true;
 
     /** See annotation */
     @Prop(

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/PropertiesConfiguration.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/PropertiesConfiguration.java
@@ -101,7 +101,17 @@ public final class PropertiesConfiguration {
         required = false,
         hidden = true,
         docComment = "Sets up the Scala toolchain for mod compilation if src/main/scala is present.")
-    public boolean scalaToolchain = true;
+    public boolean moduleScala = true;
+
+    /** See annotation */
+    @Prop(
+        name = "gtnh.modules.scala.forceEnable",
+        isSettings = false,
+        preferPopulated = false,
+        required = false,
+        hidden = true,
+        docComment = "Sets up the Scala toolchain for mod compilation unconditionally if the Scala module is enabled.")
+    public boolean forceEnableScala = false;
 
     /** See annotation */
     @Prop(

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/IdeIntegrationModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/IdeIntegrationModule.java
@@ -7,10 +7,13 @@ import com.gtnewhorizons.gtnhgradle.GTNHModule;
 import com.gtnewhorizons.gtnhgradle.PropertiesConfiguration;
 import com.gtnewhorizons.retrofuturagradle.minecraft.RunMinecraftTask;
 import org.gradle.api.GradleException;
+import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.plugins.ide.eclipse.EclipsePlugin;
+import org.gradle.plugins.ide.eclipse.model.EclipseJdt;
 import org.gradle.plugins.ide.eclipse.model.EclipseModel;
 import org.gradle.plugins.ide.idea.model.IdeaModel;
 import org.gradle.plugins.ide.idea.model.IdeaProject;
@@ -19,6 +22,7 @@ import org.jetbrains.gradle.ext.ActionDelegationConfig;
 import org.jetbrains.gradle.ext.Application;
 import org.jetbrains.gradle.ext.Gradle;
 import org.jetbrains.gradle.ext.IdeaCompilerConfiguration;
+import org.jetbrains.gradle.ext.IdeaExtPlugin;
 import org.jetbrains.gradle.ext.ProjectSettings;
 import org.jetbrains.gradle.ext.RunConfigurationContainer;
 import org.w3c.dom.Document;
@@ -60,6 +64,12 @@ public class IdeIntegrationModule implements GTNHModule {
 
     @Override
     public void apply(GTNHGradlePlugin.@NotNull GTNHExtension gtnh, @NotNull Project project) throws Throwable {
+
+        project.getPluginManager()
+            .apply(IdeaExtPlugin.class);
+        project.getPluginManager()
+            .apply(EclipsePlugin.class);
+
         final TaskContainer tasks = project.getTasks();
         final EclipseModel eclipse = project.getExtensions()
             .getByType(EclipseModel.class);
@@ -67,6 +77,14 @@ public class IdeIntegrationModule implements GTNHModule {
             .setDownloadSources(true);
         eclipse.getClasspath()
             .setDownloadJavadoc(true);
+        final EclipseJdt ejdt = eclipse.getJdt();
+        ejdt.setTargetCompatibility(JavaVersion.VERSION_1_8);
+        ejdt.setJavaRuntimeName("JavaSE-1.8");
+        if (gtnh.configuration.enableModernJavaSyntax) {
+            ejdt.setSourceCompatibility(JavaVersion.VERSION_17);
+        } else {
+            ejdt.setSourceCompatibility(JavaVersion.VERSION_1_8);
+        }
 
         final IdeaModel idea = project.getExtensions()
             .getByType(IdeaModel.class);

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/MixinModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/MixinModule.java
@@ -116,7 +116,14 @@ public class MixinModule implements GTNHModule {
 
         if (gtnh.configuration.usesMixins) {
             tasks.named("processResources")
-                .configure(t -> t.dependsOn(genTask, "compileJava", "compileScala"));
+                .configure(t -> t.dependsOn(genTask, "compileJava"));
+            project.getPluginManager()
+                .withPlugin(
+                    "scala",
+                    _plugin -> {
+                        tasks.named("processResources")
+                            .configure(t -> t.dependsOn("compileScala"));
+                    });
             tasks.named("compileJava", JavaCompile.class)
                 .configure(jc -> {
                     // Elan: from what I understand they are just some linter configs so you get some warning on how to

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/ScalaModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/ScalaModule.java
@@ -1,0 +1,41 @@
+package com.gtnewhorizons.gtnhgradle.modules;
+
+import com.gtnewhorizons.gtnhgradle.GTNHGradlePlugin;
+import com.gtnewhorizons.gtnhgradle.GTNHModule;
+import com.gtnewhorizons.gtnhgradle.PropertiesConfiguration;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.scala.ScalaPlugin;
+import org.gradle.api.tasks.scala.ScalaCompile;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.charset.StandardCharsets;
+
+/** Enables Scala support when src/main/scala exists */
+public class ScalaModule implements GTNHModule {
+
+    @Override
+    public boolean isEnabled(@NotNull PropertiesConfiguration configuration) {
+        return configuration.scalaToolchain;
+    }
+
+    @Override
+    public void apply(GTNHGradlePlugin.@NotNull GTNHExtension gtnh, @NotNull Project project) throws Throwable {
+        if (!project.file("src/main/scala")
+            .exists()) {
+            gtnh.logger.debug("No src/main/scala detected, skipping Scala initialization.");
+            return;
+        }
+
+        project.getPluginManager()
+            .apply(ScalaPlugin.class);
+
+        // Set up Scala
+        project.getTasks()
+            .withType(ScalaCompile.class)
+            .configureEach(
+                sc -> {
+                    sc.getOptions()
+                        .setEncoding(StandardCharsets.UTF_8.name());
+                });
+    }
+}

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/ScalaModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/ScalaModule.java
@@ -15,12 +15,12 @@ public class ScalaModule implements GTNHModule {
 
     @Override
     public boolean isEnabled(@NotNull PropertiesConfiguration configuration) {
-        return configuration.scalaToolchain;
+        return configuration.moduleScala;
     }
 
     @Override
     public void apply(GTNHGradlePlugin.@NotNull GTNHExtension gtnh, @NotNull Project project) throws Throwable {
-        if (!project.file("src/main/scala")
+        if (!gtnh.configuration.forceEnableScala && !project.file("src/main/scala")
             .exists()) {
             gtnh.logger.debug("No src/main/scala detected, skipping Scala initialization.");
             return;

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/ToolchainModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/ToolchainModule.java
@@ -31,7 +31,6 @@ import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.compile.JavaCompile;
-import org.gradle.api.tasks.scala.ScalaCompile;
 import org.gradle.jvm.tasks.Jar;
 import org.gradle.jvm.toolchain.JavaCompiler;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
@@ -169,14 +168,6 @@ public abstract class ToolchainModule implements GTNHModule {
                         .set(jabelCompiler);
                 });
         }
-
-        // Set up Scala
-        tasks.withType(ScalaCompile.class)
-            .configureEach(
-                sc -> {
-                    sc.getOptions()
-                        .setEncoding(StandardCharsets.UTF_8.name());
-                });
 
         // Set up Kotlin if enabled
         project.getPlugins()


### PR DESCRIPTION
 - Only initializes Scala if `src/main/scala` exists in the project
 - Incorporates @makamys's improvements to the Eclipse project configs when Jabel is enabled