### PR TITLE
Dynamically use newer spotless on Java 21 to fix crash

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,14 +51,8 @@ dependencies {
     api(pluginDep("com.github.johnrengelman.shadow", "8.1.1"))
     api(pluginDep("de.undercouch.download", "5.5.0"))
     api(pluginDep("com.github.gmazzo.buildconfig", "3.1.0")) // Unused, available for addon.gradle
-    api(pluginDep("com.diffplug.spotless", "6.13.0")) // 6.13.0 is the last jvm8 supporting version
     api(pluginDep("com.modrinth.minotaur", "2.8.7"))
     api(pluginDep("com.matthewprenger.cursegradle", "1.4.0"))
-
-    api(pluginDep("com.diffplug.spotless", "6.12.0")) {
-        exclude("org.codehaus.groovy", "groovy")
-        exclude("org.codehaus.groovy", "groovy-xml")
-    }
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.9.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/PropertiesConfiguration.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/PropertiesConfiguration.java
@@ -60,6 +60,18 @@ public final class PropertiesConfiguration {
             LOCAL to test local config updates.
             """)
     public @NotNull String blowdryerTag = UpdateableConstants.NEWEST_BLOWDRYER_TAG;
+
+    /** See annotation */
+    @Prop(
+        name = "gtnh.settings.dynamicSpotlessVersion",
+        isSettings = true,
+        preferPopulated = false,
+        required = false,
+        hidden = true,
+        docComment = """
+            Whether to enable a pluginManagement spotless version resolution rule to use a newer spotless build on new JVMs.
+            """)
+    public @NotNull boolean dynamicSpotlessVersion = true;
     // </editor-fold>
 
     // <editor-fold desc="Project properties">

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/UpdateableConstants.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/UpdateableConstants.java
@@ -33,6 +33,12 @@ public class UpdateableConstants {
     /** Latest version of LWJGL3 for modern Java support */
     // https://github.com/LWJGL/lwjgl3/releases - but check what latest Minecraft uses too
     public static final @NotNull String NEWEST_LWJGL3 = "3.3.2";
+    /** Latest version of Spotless compatible with Java 8 */
+    // https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md
+    public static final @NotNull String NEWEST_SPOTLESS_JAVA8 = "6.13.0";
+    /** Latest version of Spotless compatible with modern Java versions */
+    // https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md
+    public static final @NotNull String NEWEST_SPOTLESS = "6.25.0";
 
     /** Latest HotSwapAgent release jar URL */
     // https://github.com/HotswapProjects/HotswapAgent/releases

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/CodeStyleModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/CodeStyleModule.java
@@ -1,7 +1,6 @@
 package com.gtnewhorizons.gtnhgradle.modules;
 
 import com.diffplug.blowdryer.Blowdryer;
-import com.diffplug.gradle.spotless.SpotlessPlugin;
 import com.google.common.collect.ImmutableList;
 import com.gtnewhorizons.gtnhgradle.GTNHConstants;
 import com.gtnewhorizons.gtnhgradle.GTNHGradlePlugin;
@@ -26,8 +25,9 @@ public class CodeStyleModule implements GTNHModule {
     @Override
     public void apply(GTNHGradlePlugin.@NotNull GTNHExtension gtnh, @NotNull Project project) {
         if (!gtnh.configuration.disableSpotless) {
-            project.getPlugins()
-                .apply(SpotlessPlugin.class);
+            // Version dynamically configured by GTNHSettingsConventionPlugin
+            project.getPluginManager()
+                .apply("com.diffplug.spotless");
             project.apply(oca -> { oca.from(Blowdryer.file("spotless.gradle")); });
         }
         if (!gtnh.configuration.disableCheckstyle) {


### PR DESCRIPTION
Now that we have a custom settings plugin, it's easy to update spotless when Java 17+ is detected. The formatters are pinned to specific versions in the blowdryer settings, so this does not affect the results - but it does allow you to run gradle with java 21 now.

Tested with java 8, 17 and 21.