### PR TITLE
fix: Use the right toolchain for Java 21

### DIFF
--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/ModernJavaModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/ModernJavaModule.java
@@ -84,7 +84,7 @@ public abstract class ModernJavaModule implements GTNHModule {
             spec.getVendor()
                 .set(JvmVendorSpec.JETBRAINS); // for enhanced HotSwap
         };
-        ext.set("java21Toolchain", java17Toolchain);
+        ext.set("java21Toolchain", java21Toolchain);
         final Configuration java17DependenciesCfg = cfgs.create("java17Dependencies", c -> {
             c.extendsFrom(cfgs.getByName("runtimeClasspath"));
             c.setCanBeResolved(true);


### PR DESCRIPTION
Not sure if it's a copy&paste error or intentional.