### PR TITLE
Migrate from CurseGradle to the maintained CurseForgeGradle plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
     api(pluginDep("de.undercouch.download", "5.5.0"))
     api(pluginDep("com.github.gmazzo.buildconfig", "3.1.0")) // Unused, available for addon.gradle
     api(pluginDep("com.modrinth.minotaur", "2.8.7"))
-    api(pluginDep("com.matthewprenger.cursegradle", "1.4.0"))
+    api(pluginDep("net.darkhax.curseforgegradle", "1.1.18"))
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.9.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/src/functionalTest/java/com/gtnewhorizons/gtnhgradle/GTNHGradlePluginFunctionalTest.java
+++ b/src/functionalTest/java/com/gtnewhorizons/gtnhgradle/GTNHGradlePluginFunctionalTest.java
@@ -9,7 +9,7 @@ import java.io.Writer;
 import java.io.FileWriter;
 import java.nio.file.Files;
 
-import com.google.common.collect.ImmutableMap;
+import com.gtnewhorizons.retrofuturagradle.shadow.com.google.common.collect.ImmutableMap;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.TaskOutcome;

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/GTNHGradlePlugin.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/GTNHGradlePlugin.java
@@ -4,8 +4,8 @@
 package com.gtnewhorizons.gtnhgradle;
 
 import com.diffplug.blowdryer.Blowdryer;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import com.gtnewhorizons.retrofuturagradle.shadow.com.google.common.collect.ImmutableList;
+import com.gtnewhorizons.retrofuturagradle.shadow.com.google.common.collect.ImmutableMap;
 import com.gtnewhorizons.gtnhgradle.modules.AccessTransformerModule;
 import com.gtnewhorizons.gtnhgradle.modules.CodeStyleModule;
 import com.gtnewhorizons.gtnhgradle.modules.GitVersionModule;

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/CodeStyleModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/CodeStyleModule.java
@@ -1,7 +1,7 @@
 package com.gtnewhorizons.gtnhgradle.modules;
 
 import com.diffplug.blowdryer.Blowdryer;
-import com.google.common.collect.ImmutableList;
+import com.gtnewhorizons.retrofuturagradle.shadow.com.google.common.collect.ImmutableList;
 import com.gtnewhorizons.gtnhgradle.GTNHConstants;
 import com.gtnewhorizons.gtnhgradle.GTNHGradlePlugin;
 import com.gtnewhorizons.gtnhgradle.GTNHModule;

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/IdeIntegrationModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/IdeIntegrationModule.java
@@ -1,7 +1,7 @@
 package com.gtnewhorizons.gtnhgradle.modules;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import com.gtnewhorizons.retrofuturagradle.shadow.com.google.common.collect.ImmutableList;
+import com.gtnewhorizons.retrofuturagradle.shadow.com.google.common.collect.ImmutableMap;
 import com.gtnewhorizons.gtnhgradle.GTNHGradlePlugin;
 import com.gtnewhorizons.gtnhgradle.GTNHModule;
 import com.gtnewhorizons.gtnhgradle.PropertiesConfiguration;

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/ModernJavaModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/ModernJavaModule.java
@@ -1,6 +1,6 @@
 package com.gtnewhorizons.gtnhgradle.modules;
 
-import com.google.common.collect.ImmutableList;
+import com.gtnewhorizons.retrofuturagradle.shadow.com.google.common.collect.ImmutableList;
 import com.gtnewhorizons.gtnhgradle.GTNHGradlePlugin;
 import com.gtnewhorizons.gtnhgradle.GTNHModule;
 import com.gtnewhorizons.gtnhgradle.PropertiesConfiguration;

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/ShadowModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/ShadowModule.java
@@ -2,7 +2,7 @@ package com.gtnewhorizons.gtnhgradle.modules;
 
 import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin;
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar;
-import com.google.common.collect.ImmutableList;
+import com.gtnewhorizons.retrofuturagradle.shadow.com.google.common.collect.ImmutableList;
 import com.gtnewhorizons.gtnhgradle.GTNHGradlePlugin;
 import com.gtnewhorizons.gtnhgradle.GTNHModule;
 import com.gtnewhorizons.gtnhgradle.PropertiesConfiguration;

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/StandardScriptsModules.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/StandardScriptsModules.java
@@ -1,6 +1,6 @@
 package com.gtnewhorizons.gtnhgradle.modules;
 
-import com.google.common.collect.ImmutableList;
+import com.gtnewhorizons.retrofuturagradle.shadow.com.google.common.collect.ImmutableList;
 import com.gtnewhorizons.gtnhgradle.GTNHGradlePlugin;
 import com.gtnewhorizons.gtnhgradle.GTNHModule;
 import com.gtnewhorizons.gtnhgradle.PropertiesConfiguration;

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/ToolchainModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/ToolchainModule.java
@@ -1,7 +1,7 @@
 package com.gtnewhorizons.gtnhgradle.modules;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
+import com.gtnewhorizons.retrofuturagradle.shadow.com.google.common.collect.ImmutableMap;
+import com.gtnewhorizons.retrofuturagradle.shadow.com.google.common.collect.ImmutableSet;
 import com.gtnewhorizons.gtnhgradle.GTNHConstants;
 import com.gtnewhorizons.gtnhgradle.GTNHGradlePlugin;
 import com.gtnewhorizons.gtnhgradle.GTNHModule;


### PR DESCRIPTION
Migrates to https://github.com/Darkhax/CurseForgeGradle which is still maintained, unlike CurseGradle.

The google collections import change was needed because CFG no longer transitively pulls in google libraries, so we can use RFG's pre-shaded ones instead.