### PR TITLE
Lwjgl3ify 2.0 run configuration support

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -45,3 +45,19 @@ Bulk of the testing is done in `functionalTest` which uses [Gradle TestKit](http
 4. Check the updated files for any obvious mistakes
 5. Commit
 
+## Disabling modules
+
+GTNHGradle uses some hidden [properties](src/main/java/com/gtnewhorizons/gtnhgradle/PropertiesConfiguration.java) to disable full modules of the plugin.
+Not every combination of toggles is supported, but here are a couple useful ones for non-GTNH projects:
+```properties
+
+# Disable git-based version detection, make sure to set project.version to a sensible value yourself
+gtnh.modules.gitVersion = false
+
+# Disable all GTNH code style checks (like Spotless autoformatting, CheckStyle rules, and any future additions)
+gtnh.modules.codeStyle = false
+
+# Disables lwjgl3ify-based utilities for working with and running with modern Java versions
+gtnh.modules.modernJava = false
+
+```

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/UpdateableConstants.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/UpdateableConstants.java
@@ -26,7 +26,7 @@ public class UpdateableConstants {
     public static final @NotNull String NEWEST_GTNH_LIB = "com.github.GTNewHorizons:GTNHLib:0.2.10";
     /** Latest version of GTNHLib for modern Java support */
     // https://github.com/GTNewHorizons/lwjgl3ify/releases
-    public static final @NotNull String NEWEST_LWJGL3IFY = "com.github.GTNewHorizons:lwjgl3ify:1.5.16";
+    public static final @NotNull String NEWEST_LWJGL3IFY = "com.github.GTNewHorizons:lwjgl3ify:2.0.0";
     /** Latest version of GTNHLib for modern Java support */
     // https://github.com/GTNewHorizons/Hodgepodge/releases
     public static final @NotNull String NEWEST_HODGEPODGE = "com.github.GTNewHorizons:Hodgepodge:2.4.35";

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/UpdateableConstants.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/UpdateableConstants.java
@@ -29,7 +29,7 @@ public class UpdateableConstants {
     public static final @NotNull String NEWEST_LWJGL3IFY = "com.github.GTNewHorizons:lwjgl3ify:1.5.16";
     /** Latest version of GTNHLib for modern Java support */
     // https://github.com/GTNewHorizons/Hodgepodge/releases
-    public static final @NotNull String NEWEST_HODGEPODGE = "com.github.GTNewHorizons:Hodgepodge:2.4.34";
+    public static final @NotNull String NEWEST_HODGEPODGE = "com.github.GTNewHorizons:Hodgepodge:2.4.35";
     /** Latest version of LWJGL3 for modern Java support */
     // https://github.com/LWJGL/lwjgl3/releases - but check what latest Minecraft uses too
     public static final @NotNull String NEWEST_LWJGL3 = "3.3.2";

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/IdeIntegrationModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/IdeIntegrationModule.java
@@ -130,27 +130,29 @@ public class IdeIntegrationModule implements GTNHModule {
         runs.register("0. Build and Test", Gradle.class, run -> { run.setTaskNames(ImmutableList.of("build")); });
         runs.register("1. Run Client", Gradle.class, run -> { run.setTaskNames(ImmutableList.of("runClient")); });
         runs.register("2. Run Server", Gradle.class, run -> { run.setTaskNames(ImmutableList.of("runServer")); });
-        char suffix = 'a';
-        for (final int javaVer : ImmutableList.of(17, 21)) {
-            final char mySuffix = suffix;
-            final char myHsSuffix = (char) (suffix + 1);
-            suffix += 2;
-            runs.register(
-                "1" + mySuffix + ". Run Client (Java " + javaVer + ")",
-                Gradle.class,
-                run -> { run.setTaskNames(ImmutableList.of("runClient" + javaVer)); });
-            runs.register(
-                "2" + mySuffix + ". Run Server (Java " + javaVer + ")",
-                Gradle.class,
-                run -> { run.setTaskNames(ImmutableList.of("runServer" + javaVer)); });
-            runs.register("1" + myHsSuffix + ". Run Client (Java " + javaVer + ", Hotswap)", Gradle.class, run -> {
-                run.setTaskNames(ImmutableList.of("runClient" + javaVer));
-                run.setEnvs(ImmutableMap.of("HOTSWAP", "true"));
-            });
-            runs.register("2" + myHsSuffix + ". Run Server (Java " + javaVer + ", Hotswap)", Gradle.class, run -> {
-                run.setTaskNames(ImmutableList.of("runServer" + javaVer));
-                run.setEnvs(ImmutableMap.of("HOTSWAP", "true"));
-            });
+        if (gtnh.configuration.moduleModernJava) {
+            char suffix = 'a';
+            for (final int javaVer : ImmutableList.of(17, 21)) {
+                final char mySuffix = suffix;
+                final char myHsSuffix = (char) (suffix + 1);
+                suffix += 2;
+                runs.register(
+                    "1" + mySuffix + ". Run Client (Java " + javaVer + ")",
+                    Gradle.class,
+                    run -> { run.setTaskNames(ImmutableList.of("runClient" + javaVer)); });
+                runs.register(
+                    "2" + mySuffix + ". Run Server (Java " + javaVer + ")",
+                    Gradle.class,
+                    run -> { run.setTaskNames(ImmutableList.of("runServer" + javaVer)); });
+                runs.register("1" + myHsSuffix + ". Run Client (Java " + javaVer + ", Hotswap)", Gradle.class, run -> {
+                    run.setTaskNames(ImmutableList.of("runClient" + javaVer));
+                    run.setEnvs(ImmutableMap.of("HOTSWAP", "true"));
+                });
+                runs.register("2" + myHsSuffix + ". Run Server (Java " + javaVer + ", Hotswap)", Gradle.class, run -> {
+                    run.setTaskNames(ImmutableList.of("runServer" + javaVer));
+                    run.setEnvs(ImmutableMap.of("HOTSWAP", "true"));
+                });
+            }
         }
         runs.register(
             "3. Run Obfuscated Client",
@@ -303,7 +305,8 @@ public class IdeIntegrationModule implements GTNHModule {
             .configure(t -> {
                 // Make IntelliJ "Build project" build the mod jars
                 t.dependsOn("jar", "reobfJar");
-                if (!gtnh.configuration.disableSpotless && gtnh.configuration.ideaCheckSpotlessOnBuild) {
+                if (gtnh.configuration.moduleCodeStyle && !gtnh.configuration.disableSpotless
+                    && gtnh.configuration.ideaCheckSpotlessOnBuild) {
                     t.dependsOn("spotlessCheck");
                 }
             });

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/ModernJavaModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/ModernJavaModule.java
@@ -32,16 +32,18 @@ import java.util.List;
 public abstract class ModernJavaModule implements GTNHModule {
 
     /** Default Java 17 JVM arguments */
-    public final String[] JAVA_17_ARGS = new String[] { "-Dfile.encoding=UTF-8", "-Djava.security.manager=allow",
-        "--add-opens", "java.base/jdk.internal.loader=ALL-UNNAMED", "--add-opens", "java.base/java.net=ALL-UNNAMED",
-        "--add-opens", "java.base/java.nio=ALL-UNNAMED", "--add-opens", "java.base/java.io=ALL-UNNAMED", "--add-opens",
-        "java.base/java.lang=ALL-UNNAMED", "--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED", "--add-opens",
-        "java.base/java.text=ALL-UNNAMED", "--add-opens", "java.base/java.util=ALL-UNNAMED", "--add-opens",
-        "java.base/jdk.internal.reflect=ALL-UNNAMED", "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED", "--add-opens",
-        "jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED,java.naming", "--add-opens",
-        "java.desktop/sun.awt.image=ALL-UNNAMED", "--add-modules", "jdk.dynalink", "--add-opens",
-        "jdk.dynalink/jdk.dynalink.beans=ALL-UNNAMED", "--add-modules", "java.sql.rowset", "--add-opens",
-        "java.sql.rowset/javax.sql.rowset.serial=ALL-UNNAMED" };
+    public final String[] JAVA_17_ARGS = new String[] { "-Dfile.encoding=UTF-8",
+        "-Djava.system.class.loader=com.gtnewhorizons.retrofuturabootstrap.RfbSystemClassLoader",
+        "-Djava.security.manager=allow", "--add-opens", "java.base/jdk.internal.loader=ALL-UNNAMED", "--add-opens",
+        "java.base/java.net=ALL-UNNAMED", "--add-opens", "java.base/java.nio=ALL-UNNAMED", "--add-opens",
+        "java.base/java.io=ALL-UNNAMED", "--add-opens", "java.base/java.lang=ALL-UNNAMED", "--add-opens",
+        "java.base/java.lang.reflect=ALL-UNNAMED", "--add-opens", "java.base/java.text=ALL-UNNAMED", "--add-opens",
+        "java.base/java.util=ALL-UNNAMED", "--add-opens", "java.base/jdk.internal.reflect=ALL-UNNAMED", "--add-opens",
+        "java.base/sun.nio.ch=ALL-UNNAMED", "--add-opens", "jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED,java.naming",
+        "--add-opens", "java.desktop/sun.awt=ALL-UNNAMED", "--add-opens", "java.desktop/sun.awt.image=ALL-UNNAMED",
+        "--add-opens", "java.desktop/com.sun.imageio.plugins.png=ALL-UNNAMED", "--add-opens",
+        "jdk.dynalink/jdk.dynalink.beans=ALL-UNNAMED", "--add-opens",
+        "java.sql.rowset/javax.sql.rowset.serial=ALL-UNNAMED", };
     /** Default Java HotSwapAgent JVM arguments */
     public final String[] HOTSWAP_JVM_ARGS = new String[] {
         // DCEVM advanced hot reload

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/tasks/RunHotswappableMinecraftTask.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/tasks/RunHotswappableMinecraftTask.java
@@ -113,6 +113,10 @@ public abstract class RunHotswappableMinecraftTask extends RunMinecraftTask {
             getExtraArgs().add("nogui");
         }
 
+        // Use RFB alternate main class
+        systemProperty("gradlestart.bouncerClient", "com.gtnewhorizons.retrofuturabootstrap.Main");
+        systemProperty("gradlestart.bouncerServer", "com.gtnewhorizons.retrofuturabootstrap.Main");
+
         if (gtnh.configuration.usesMixins) {
             this.getExtraJvmArgs()
                 .addAll(project.provider(() -> {

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/tasks/UpdateDependenciesTask.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/tasks/UpdateDependenciesTask.java
@@ -44,8 +44,11 @@ public abstract class UpdateDependenciesTask extends DefaultTask {
     @PathSensitive(PathSensitivity.NAME_ONLY)
     public abstract RegularFileProperty getDependenciesGradle();
 
+    /**
+     * For dependency injection
+     */
     @Inject
-    public UpdateDependenciesTask() {
+    protected UpdateDependenciesTask() {
         this.setGroup("GTNH Buildscript");
         this.setDescription("Updates dependencies under GTNH maven to the latest versions");
         // Ensure the task always runs
@@ -53,13 +56,18 @@ public abstract class UpdateDependenciesTask extends DefaultTask {
             .upToDateWhen(Specs.satisfyNone());
     }
 
+    /**
+     * Updates the dependencies in dependencies.gradle
+     *
+     * @throws IOException in case of underlying disk and network errors
+     */
     @TaskAction
     public void updateDependencies() throws IOException {
         File dependenciesFile = getDependenciesGradle().getAsFile()
             .get();
         Path dependenciesPath = dependenciesFile.toPath();
         if (!dependenciesFile.isFile()) {
-            getLogger().error("File does not exist: " + dependenciesPath);
+            getLogger().error("File does not exist: {}", dependenciesPath);
             return;
         }
 
@@ -80,7 +88,7 @@ public abstract class UpdateDependenciesTask extends DefaultTask {
                 continue;
             }
             if (versions.isEmpty()) {
-                getLogger().warn(String.format("No releases found on %s", modName));
+                getLogger().warn("No releases found on {}", modName);
                 continue;
             }
             int currentVersionIndex = -1;
@@ -98,14 +106,14 @@ public abstract class UpdateDependenciesTask extends DefaultTask {
                 }
             }
             if (latestVersionIndex == -1) {
-                getLogger().warn(String.format("%s does not contain non-pre release", modName));
+                getLogger().warn("{} does not contain non-pre release", modName);
                 continue;
             }
             // currentVersionIndex == -1 can happen when release is removed from maven
             if (latestVersionIndex > currentVersionIndex) {
                 String newVersion = versions.get(latestVersionIndex);
                 lines.set(lineIndex, line.replace(currentVersion, newVersion));
-                getLogger().lifecycle(String.format("Updated %s: %s -> %s", modName, currentVersion, newVersion));
+                getLogger().lifecycle("Updated {}: {} -> {}", modName, currentVersion, newVersion);
                 updated = true;
             }
         }


### PR DESCRIPTION
Updates the lwjgl3ify run configurations to 2.0.0 with RFB, and fixes a couple minor missing conditions around IDE integration code when running with code style/modern java modules fully disabled.