### PR TITLE
Update RFG and add a propertiesHelp task to print a list of all available properties

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -61,3 +61,5 @@ gtnh.modules.codeStyle = false
 gtnh.modules.modernJava = false
 
 ```
+
+Run `./gradlew propertiesHelp` to list all the available properties along with their descriptions.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
     annotationProcessor("net.java.dev.jna:jna-platform:5.13.0")
 
     // All these plugins will be present in the classpath of the project using our plugin, but not activated until explicitly applied
-    api(pluginDep("com.gtnewhorizons.retrofuturagradle","1.3.35"))
+    api(pluginDep("com.gtnewhorizons.retrofuturagradle","1.4.0"))
 
     // Settings plugins
     api(pluginDep("com.diffplug.blowdryerSetup", "1.7.1"))
@@ -50,11 +50,11 @@ dependencies {
     api(pluginDep("org.jetbrains.kotlin.kapt", "1.8.0"))
     api(pluginDep("com.google.devtools.ksp", "1.8.0-1.0.9"))
     api(pluginDep("org.ajoberstar.grgit", "4.1.1")) // 4.1.1 is the last jvm8 supporting version, unused, available for addon.gradle
-    api(pluginDep("com.github.johnrengelman.shadow", "8.1.1"))
+    api(pluginDep("io.github.goooler.shadow", "8.1.7"))
     api(pluginDep("de.undercouch.download", "5.6.0"))
     api(pluginDep("com.github.gmazzo.buildconfig", "3.1.0")) // Unused, available for addon.gradle
     api(pluginDep("com.modrinth.minotaur", "2.8.7"))
-    api(pluginDep("net.darkhax.curseforgegradle", "1.1.23"))
+    api(pluginDep("net.darkhax.curseforgegradle", "1.1.24"))
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.9.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/UpdateableConstants.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/UpdateableConstants.java
@@ -10,7 +10,7 @@ public class UpdateableConstants {
     /** Latest Gradle version to update to. */
     // https://github.com/gradle/gradle/releases
     @SuppressWarnings("unused") // Used via reflection
-    public static final @NotNull String NEWEST_GRADLE_VERSION = "8.7";
+    public static final @NotNull String NEWEST_GRADLE_VERSION = "8.8";
 
     /** Latest tag of ExampleMod with blowdryer settings */
     // https://github.com/GTNewHorizons/ExampleMod1.7.10/releases
@@ -26,10 +26,10 @@ public class UpdateableConstants {
     public static final @NotNull String NEWEST_GTNH_LIB = "com.github.GTNewHorizons:GTNHLib:0.2.11";
     /** Latest version of GTNHLib for modern Java support */
     // https://github.com/GTNewHorizons/lwjgl3ify/releases
-    public static final @NotNull String NEWEST_LWJGL3IFY = "com.github.GTNewHorizons:lwjgl3ify:2.0.6";
+    public static final @NotNull String NEWEST_LWJGL3IFY = "com.github.GTNewHorizons:lwjgl3ify:2.0.9";
     /** Latest version of GTNHLib for modern Java support */
     // https://github.com/GTNewHorizons/Hodgepodge/releases
-    public static final @NotNull String NEWEST_HODGEPODGE = "com.github.GTNewHorizons:Hodgepodge:2.4.42";
+    public static final @NotNull String NEWEST_HODGEPODGE = "com.github.GTNewHorizons:Hodgepodge:2.5.19";
     /** Latest version of LWJGL3 for modern Java support */
     // https://github.com/LWJGL/lwjgl3/releases - but check what latest Minecraft uses too
     public static final @NotNull String NEWEST_LWJGL3 = "3.3.2";

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/IdeIntegrationModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/IdeIntegrationModule.java
@@ -180,10 +180,9 @@ public class IdeIntegrationModule implements GTNHModule {
             run.setWorkingDirectory(
                 runClient.getWorkingDir()
                     .getAbsolutePath());
-            run.setProgramParameters(quotedJoin(runClient.calculateArgs(project)));
+            run.setProgramParameters(quotedJoin(runClient.calculateArgs()));
             run.setJvmArgs(
-                quotedJoin(runClient.calculateJvmArgs(project)) + ' '
-                    + quotedPropJoin(runClient.getSystemProperties()));
+                quotedJoin(runClient.calculateJvmArgs()) + ' ' + quotedPropJoin(runClient.getSystemProperties()));
         });
         final var ijServerRun = runs.register("Run Server (IJ Native)", Application.class, run -> {
             run.setMainClass("GradleStartServer");
@@ -196,10 +195,9 @@ public class IdeIntegrationModule implements GTNHModule {
             run.setWorkingDirectory(
                 runServer.getWorkingDir()
                     .getAbsolutePath());
-            run.setProgramParameters(quotedJoin(runServer.calculateArgs(project)));
+            run.setProgramParameters(quotedJoin(runServer.calculateArgs()));
             run.setJvmArgs(
-                quotedJoin(runServer.calculateJvmArgs(project)) + ' '
-                    + quotedPropJoin(runServer.getSystemProperties()));
+                quotedJoin(runServer.calculateJvmArgs()) + ' ' + quotedPropJoin(runServer.getSystemProperties()));
         });
 
         ideaExt.withIDEADir(ideaDir -> {

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/UtilityModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/UtilityModule.java
@@ -61,6 +61,12 @@ public class UtilityModule implements GTNHModule {
                 });
         });
 
+        tasks.register("propertiesHelp", t -> {
+            t.setGroup("GTNH Buildscript");
+            t.setDescription("Prints descriptions for all the settings available in gradle.properties");
+            t.doLast(inner -> { PropertiesConfiguration.printPropertyDocs(System.out); });
+        });
+
         tasks.register("deobfParams", t -> {
             t.setGroup("GTNH Buildscript");
             t.setDescription("Rename all obfuscated parameter names inherited from Minecraft classes");


### PR DESCRIPTION
- Fix various issues with missing mapping files, e.g. when running `rfg.deobf` with an empty cache
- Update Gradle to 8.8
- Update RFG to 1.4.0
- Add a propertiesHelp task to print a list of all available properties, including the hidden ones:
![image](https://github.com/GTNewHorizons/GTNHGradle/assets/1017004/c8e2688e-7445-48b1-8fcc-e91df143dd48)
