### PR TITLE
Better support non-git-versioned projects

### DIFF
--- a/src/main/java/com/gtnewhorizons/gtnhgradle/PropertiesConfiguration.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/PropertiesConfiguration.java
@@ -84,7 +84,10 @@ public final class PropertiesConfiguration {
         preferPopulated = false,
         required = false,
         hidden = true,
-        docComment = "Whether to automatically set the version based on the VERSION environment variable or the current git status.")
+        docComment = """
+            Whether to automatically set the version based on the VERSION environment variable or the current git status.
+            If not used, make sure to set project.ext.modVersion to a String with a correct version number during project evaluation.
+            """)
     public boolean moduleGitVersion = true;
 
     /** See annotation */

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/GitVersionModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/GitVersionModule.java
@@ -14,8 +14,6 @@ import org.gradle.api.Project;
 import org.gradle.api.plugins.ExtraPropertiesExtension;
 import org.jetbrains.annotations.NotNull;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.regex.Pattern;
 
 /**
@@ -32,19 +30,7 @@ public class GitVersionModule implements GTNHModule {
 
     @Override
     public void apply(GTNHGradlePlugin.@NotNull GTNHExtension gtnh, @NotNull Project project) {
-        final Path projectDir = gtnh.getProjectLayout()
-            .getProjectDirectory()
-            .getAsFile()
-            .toPath();
         String versionOverride = System.getenv("VERSION");
-        // In submodules, .git is a file pointing to the real git dir
-        final boolean isAGitRepo = Files.exists(projectDir.resolve(".git"));
-
-        if (!isAGitRepo && versionOverride == null) {
-            gtnh.logger.error(
-                "Project is not a git repository, and no VERSION override was set. Either initialize a git repo, set a VERSION environment variable override, or disable the gitVersion module.");
-            throw new IllegalStateException("Not a git repo, and no VERSION set.");
-        }
 
         // Pulls version first from the VERSION env and then git tag
         String identifiedVersion;
@@ -82,12 +68,18 @@ public class GitVersionModule implements GTNHModule {
             } else {
                 identifiedVersion = versionOverride;
             }
-        } catch (Exception ignored) {
-            gtnh.logger.error("""
-                This mod must be version controlled by Git AND the repository must provide at least one tag,
-                or the VERSION override must be set! (Do NOT download from GitHub using the ZIP option, instead
-                clone the repository, see https://gtnh.miraheze.org/wiki/Development for details.
-                """);
+        } catch (Exception underlyingError) {
+            gtnh.logger.debug("Could not use the Git version source", underlyingError);
+            gtnh.logger.error(
+                """
+                    This mod must be version controlled by Git AND the repository must provide at least one Git tag,
+                    or the VERSION override must be set! (Do NOT download from GitHub using the ZIP option, instead
+                    clone the repository, see https://gtnh.miraheze.org/wiki/Development for details.
+
+                    If you don't want Git-based versioning, you can also replace it with a custom mechanism by setting
+                    gtnh.modules.gitVersion = false
+                    in your project's gradle.properties file, and populating project.ext.modVersion with a valid string in your buildscript.
+                    """);
             versionOverride = "NO-GIT-TAG-SET";
             identifiedVersion = versionOverride;
         }

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/GitVersionModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/GitVersionModule.java
@@ -11,6 +11,7 @@ import com.palantir.gradle.gitversion.GitVersionPlugin;
 import com.palantir.gradle.gitversion.VersionDetails;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Project;
+import org.gradle.api.plugins.ExtraPropertiesExtension;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.file.Files;
@@ -91,9 +92,11 @@ public class GitVersionModule implements GTNHModule {
             identifiedVersion = versionOverride;
         }
         project.setVersion(identifiedVersion);
-        project.getExtensions()
-            .getExtraProperties()
-            .set(GTNHConstants.MOD_VERSION_PROPERTY, identifiedVersion);
+        ExtraPropertiesExtension extraProps = project.getExtensions()
+            .getExtraProperties();
+        if (!extraProps.has(GTNHConstants.MOD_VERSION_PROPERTY)) {
+            extraProps.set(GTNHConstants.MOD_VERSION_PROPERTY, identifiedVersion);
+        }
 
         if (identifiedVersion.equals(versionOverride)) {
             gtnh.logger.warn("Version override set to {}!", identifiedVersion);

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/ToolchainModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/ToolchainModule.java
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.java.archives.Manifest;
 import org.gradle.api.plugins.BasePluginExtension;
+import org.gradle.api.plugins.ExtraPropertiesExtension;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.MapProperty;
@@ -264,14 +265,15 @@ public abstract class ToolchainModule implements GTNHModule {
             }
         }
         if (!gtnh.configuration.gradleTokenVersion.isEmpty()) {
+            ExtraPropertiesExtension extraProps = project.getExtensions()
+                .getExtraProperties();
             minecraft.getInjectedTags()
                 .put(
                     gtnh.configuration.gradleTokenVersion,
-                    Objects.requireNonNull(
-                        project.getExtensions()
-                            .getExtraProperties()
-                            .get(GTNHConstants.MOD_VERSION_PROPERTY))
-                        .toString());
+                    project.getProviders()
+                        .provider(
+                            () -> Objects.requireNonNull(extraProps.get(GTNHConstants.MOD_VERSION_PROPERTY))
+                                .toString()));
         }
 
         // Other assorted settings


### PR DESCRIPTION
- Lazily read the modVersion property to make it much easier to correctly set it in build.gradle without messing with custom plugin module application order - now it can be set after applying the convention plugin
- Don't check for a `.git` directory - just let the git version plugin figure out any errors and print out a useful warning message (while allowing the build to continue with a clearly "broken" version string) to support more scenarios of projects embedded as subprojects/submodules etc.

Fixes #17 