### PR TITLE
Add a release version property

### DIFF
--- a/src/main/java/com/gtnewhorizons/gtnhgradle/PropertiesConfiguration.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/PropertiesConfiguration.java
@@ -743,6 +743,20 @@ public final class PropertiesConfiguration {
             This is meant to be set in $HOME/.gradle/gradle.properties.
             """)
     public boolean ideaCheckSpotlessOnBuild = true;
+
+    @Prop(
+        name = "releaseType",
+        isSettings = false,
+        preferPopulated = false,
+        required = false,
+        defaultInComment = "release",
+        docComment = """
+            This project's release type on CurseForge and/or Modrinth.
+            Alternatively this can be set with the 'RELEASE_TYPE' environment variable.
+            Allowed types: release, beta, alpha
+            Leave blank to use the old release type, with -pre designations
+            """)
+    public String releaseType = "release";
     // </editor-fold>
     // </editor-fold>
 

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/PublishingModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/PublishingModule.java
@@ -102,8 +102,19 @@ public class PublishingModule implements GTNHModule {
                 .set(gtnh.configuration.modrinthProjectId);
             mr.getVersionNumber()
                 .set(modVersion);
-            mr.getVersionType()
-                .set(modVersion.map(v -> v.endsWith("-pre") ? "beta" : "release"));
+            String versionType = System.getenv("RELEASE_TYPE");
+            if (versionType != null) {
+                mr.getVersionType()
+                    .set(versionType);
+            } else {
+                if (!gtnh.configuration.releaseType.isEmpty()) {
+                    mr.getVersionType()
+                        .set(gtnh.configuration.releaseType);
+                } else {
+                    mr.getVersionType()
+                        .set(modVersion.map(v -> v.endsWith("-pre") ? "beta" : "release"));
+                }
+            }
             if (changelogFile.exists()) {
                 final String contents = new String(Files.readAllBytes(changelogFile.toPath()), StandardCharsets.UTF_8);
                 mr.getChangelog()
@@ -168,7 +179,16 @@ public class PublishingModule implements GTNHModule {
                             artifact.changelogType = "markdown";
                             artifact.changelog = changelogFile;
                         }
-                        artifact.releaseType = modVersion.map(v -> v.endsWith("-pre") ? "beta" : "release");
+                        String versionType = System.getenv("RELEASE_TYPE");
+                        if (versionType != null) {
+                            artifact.releaseType = versionType;
+                        } else {
+                            if (!gtnh.configuration.releaseType.isEmpty()) {
+                                artifact.releaseType = gtnh.configuration.releaseType;
+                            } else {
+                                artifact.releaseType = modVersion.map(v -> v.endsWith("-pre") ? "beta" : "release");
+                            }
+                        }
                         artifact.addGameVersion(gtnh.minecraftVersion.version, "Forge");
                         artifact.addModLoader("Forge");
 


### PR DESCRIPTION
Adds a `release` version property, similar to the 1.12.2 buildscripts. This allows for some more control over the release type of the project, without having to name the build a certain way. Also allows for alpha releases, which was not possible in the previous system.

If this property is left empty, then the old system of `-pre` = beta, else release is used.

Also introduces the use of an environment variable to set the release type, to mimic the 1.12.2 buildscripts.