### PR TITLE
Do not register Maven for publication if it's disabled, full stop

### DIFF
--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/PublishingModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/PublishingModule.java
@@ -76,7 +76,8 @@ public class PublishingModule implements GTNHModule {
                                 .toString()));
                     mvn.setArtifactId(ObjectUtils.firstNonNull(System.getenv("ARTIFACT_ID"), project.getName()));
                     project.afterEvaluate(
-                        _p -> mvn.setVersion(ObjectUtils.firstNonNull(System.getenv("RELEASE_VERSION"), modVersion.get())));
+                        _p -> mvn
+                            .setVersion(ObjectUtils.firstNonNull(System.getenv("RELEASE_VERSION"), modVersion.get())));
                 });
             if (mavenUser != null) {
                 publishing.getRepositories()

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/PublishingModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/PublishingModule.java
@@ -56,38 +56,40 @@ public class PublishingModule implements GTNHModule {
                 .toString());
 
         // Maven
-        publishing.getPublications()
-            .register("maven", MavenPublication.class, mvn -> {
-                mvn.from(
-                    project.getComponents()
-                        .findByName("java"));
-                if (!gtnh.configuration.apiPackage.isEmpty()) {
-                    mvn.artifact(
-                        project.getTasks()
-                            .findByName("apiJar"));
-                }
-                mvn.setGroupId(
-                    ObjectUtils.firstNonNull(
-                        System.getenv("ARTIFACT_GROUP_ID"),
-                        project.getGroup()
-                            .toString()));
-                mvn.setArtifactId(ObjectUtils.firstNonNull(System.getenv("ARTIFACT_ID"), project.getName()));
-                project.afterEvaluate(
-                    _p -> mvn.setVersion(ObjectUtils.firstNonNull(System.getenv("RELEASE_VERSION"), modVersion.get())));
-            });
         final String mavenUser = System.getenv("MAVEN_USER");
         final String mavenPass = System.getenv("MAVEN_PASSWORD");
-        if (gtnh.configuration.usesMavenPublishing && mavenUser != null) {
-            publishing.getRepositories()
-                .maven(mvn -> {
-                    mvn.setName("main");
-                    mvn.setUrl(gtnh.configuration.mavenPublishUrl);
-                    mvn.setAllowInsecureProtocol(gtnh.configuration.mavenPublishUrl.startsWith("http://"));
-                    mvn.getCredentials()
-                        .setUsername(ObjectUtils.firstNonNull(mavenUser, "NONE"));
-                    mvn.getCredentials()
-                        .setPassword(ObjectUtils.firstNonNull(mavenPass, "NONE"));
+        if (gtnh.configuration.usesMavenPublishing) {
+            publishing.getPublications()
+                .register("maven", MavenPublication.class, mvn -> {
+                    mvn.from(
+                        project.getComponents()
+                            .findByName("java"));
+                    if (!gtnh.configuration.apiPackage.isEmpty()) {
+                        mvn.artifact(
+                            project.getTasks()
+                                .findByName("apiJar"));
+                    }
+                    mvn.setGroupId(
+                        ObjectUtils.firstNonNull(
+                            System.getenv("ARTIFACT_GROUP_ID"),
+                            project.getGroup()
+                                .toString()));
+                    mvn.setArtifactId(ObjectUtils.firstNonNull(System.getenv("ARTIFACT_ID"), project.getName()));
+                    project.afterEvaluate(
+                        _p -> mvn.setVersion(ObjectUtils.firstNonNull(System.getenv("RELEASE_VERSION"), modVersion.get())));
                 });
+            if (mavenUser != null) {
+                publishing.getRepositories()
+                    .maven(mvn -> {
+                        mvn.setName("main");
+                        mvn.setUrl(gtnh.configuration.mavenPublishUrl);
+                        mvn.setAllowInsecureProtocol(gtnh.configuration.mavenPublishUrl.startsWith("http://"));
+                        mvn.getCredentials()
+                            .setUsername(ObjectUtils.firstNonNull(mavenUser, "NONE"));
+                        mvn.getCredentials()
+                            .setPassword(ObjectUtils.firstNonNull(mavenPass, "NONE"));
+                    });
+            }
         }
 
         final File changelogFile = new File(ObjectUtils.firstNonNull(System.getenv("CHANGELOG_FILE"), "CHANGELOG.md"));


### PR DESCRIPTION
Registering a `MavenPublication` instance causes so many headaches/issues for people trying to set up their own publishing (e.g. to GitHub Packages). The `usesMavenPublishing` property does not fully disable all of the Maven publishing behaviour. It disables the stuff related to altering any repositories but does not stop from registering the publication.

See my current ongoing GitHub Actions failures [here](https://github.com/glektarssza/minecraft-gtnh-customizer/actions) for examples of this behaviour causing issues.

This PR changes that behaviour so that setting `usesMavenPublishing` to `false` completely disables Maven publishing inside the Gradle plugin.