### PR TITLE
update comment about the mixinsPackage property

### DIFF
--- a/src/main/java/com/gtnewhorizons/gtnhgradle/PropertiesConfiguration.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/PropertiesConfiguration.java
@@ -474,7 +474,7 @@ public final class PropertiesConfiguration {
         preferPopulated = true,
         required = false,
         docComment = """
-            Specify the package that contains all of your Mixins. You may only place Mixins in this package or the build will fail!
+            Specify the package that contains all of your Mixins.
             """)
     public @NotNull String mixinsPackage = "";
 


### PR DESCRIPTION
it is not true that the build will fail if the package contains something other than Mixins classes so I am removing the comment since it's is missleading