### PR TITLE
Remove KGP

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,9 +50,6 @@ dependencies {
     api(pluginDep("com.gradleup.shadow", "8.3.9"))
     api(pluginDep("com.palantir.git-version", "3.4.0"))
     api(pluginDep("org.jetbrains.gradle.plugin.idea-ext", "1.1.10"))
-    api(pluginDep("org.jetbrains.kotlin.jvm", "2.1.10"))
-    api(pluginDep("org.jetbrains.kotlin.kapt", "2.1.10"))
-    api(pluginDep("com.google.devtools.ksp", "2.1.10-1.0.29")) // 1.0.29 is the last jvm8 supporting version
     api(pluginDep("org.ajoberstar.grgit", "4.1.1")) // 4.1.1 is the last jvm8 supporting version, unused, available for addon.gradle
     api(pluginDep("de.undercouch.download", "5.6.0"))
     api(pluginDep("com.github.gmazzo.buildconfig", "5.5.4")) // 5.5.4 is the last jvm8 supporting version, unused, available for addon.gradle

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/ToolchainModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/ToolchainModule.java
@@ -183,11 +183,13 @@ public abstract class ToolchainModule implements GTNHModule {
         // Set up Kotlin if enabled
         project.getPlugins()
             .withId("org.jetbrains.kotlin.jvm", plugin -> {
-                Object extension = project.getExtensions().getByName("kotlin");
+                Object extension = project.getExtensions()
+                    .getByName("kotlin");
                 try {
                     // Use reflection to remove the kgp dependency
                     // kotlin.jvmToolchain(8)
-                    Method jvmToolchainMethod = extension.getClass().getMethod("jvmToolchain", Integer.TYPE);
+                    Method jvmToolchainMethod = extension.getClass()
+                        .getMethod("jvmToolchain", Integer.TYPE);
                     jvmToolchainMethod.invoke(extension, 8);
                 } catch (Throwable t) {
                     throw new RuntimeException(t);

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/ToolchainModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/ToolchainModule.java
@@ -1,9 +1,5 @@
 package com.gtnewhorizons.gtnhgradle.modules;
 
-import com.gtnewhorizons.retrofuturagradle.minecraft.RunMinecraftTask;
-import com.gtnewhorizons.retrofuturagradle.modutils.ModUtils;
-import com.gtnewhorizons.retrofuturagradle.shadow.com.google.common.collect.ImmutableMap;
-import com.gtnewhorizons.retrofuturagradle.shadow.com.google.common.collect.ImmutableSet;
 import com.gtnewhorizons.gtnhgradle.GTNHConstants;
 import com.gtnewhorizons.gtnhgradle.GTNHGradlePlugin;
 import com.gtnewhorizons.gtnhgradle.GTNHModule;
@@ -14,6 +10,10 @@ import com.gtnewhorizons.retrofuturagradle.ObfuscationAttribute;
 import com.gtnewhorizons.retrofuturagradle.mcp.InjectTagsTask;
 import com.gtnewhorizons.retrofuturagradle.mcp.MCPTasks;
 import com.gtnewhorizons.retrofuturagradle.mcp.ReobfuscatedJar;
+import com.gtnewhorizons.retrofuturagradle.minecraft.RunMinecraftTask;
+import com.gtnewhorizons.retrofuturagradle.modutils.ModUtils;
+import com.gtnewhorizons.retrofuturagradle.shadow.com.google.common.collect.ImmutableMap;
+import com.gtnewhorizons.retrofuturagradle.shadow.com.google.common.collect.ImmutableSet;
 import com.gtnewhorizons.retrofuturagradle.util.ProviderToStringWrapper;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -43,9 +43,9 @@ import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.jvm.toolchain.JvmVendorSpec;
 import org.gradle.language.jvm.tasks.ProcessResources;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.kotlin.gradle.dsl.KotlinBaseExtension;
 
 import javax.inject.Inject;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Objects;
@@ -183,9 +183,15 @@ public abstract class ToolchainModule implements GTNHModule {
         // Set up Kotlin if enabled
         project.getPlugins()
             .withId("org.jetbrains.kotlin.jvm", plugin -> {
-                final KotlinBaseExtension kotlin = (KotlinBaseExtension) project.getExtensions()
-                    .getByName("kotlin");
-                kotlin.jvmToolchain(8);
+                Object extension = project.getExtensions().getByName("kotlin");
+                try {
+                    // Use reflection to remove the kgp dependency
+                    // kotlin.jvmToolchain(8)
+                    Method jvmToolchainMethod = extension.getClass().getMethod("jvmToolchain", Integer.TYPE);
+                    jvmToolchainMethod.invoke(extension, 8);
+                } catch (Throwable t) {
+                    throw new RuntimeException(t);
+                }
                 final Set<String> disabledKotlinTasks = ImmutableSet.of(
                     "kaptGenerateStubsMcLauncherKotlin",
                     "kaptGenerateStubsPatchedMcKotlin",


### PR DESCRIPTION
Remove the Kotlin Gradle Plugin dependency, so that the users can freely choose the version of Kotlin.

The original functionalities for KGP are kept by using reflect.

Tested and worked well with my local projects, with and without Kotlin.

You can use `$env:VERSION="99.99.99"; ./gradlew publishToMavenLocal -x javadoc` to publish it to your local maven and test.
