### PR TITLE
Set Eclipse JDT compliance version to target compatibility version during Eclipse IDE file generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,33 +1,95 @@
-.gradle
-.settings
-/.idea/
-/.vscode/
-/run/
-run/
-build/
-/eclipse/
-.classpath
+# Editors #
+## Visual Studio Code ##
+### Workspace Folder ###
+.vscode/*
+
+### Local History ###
+.history/
+
+### Built Visual Studio Code Extensions ###
+*.vsix
+
+## Eclipse ##
 .project
-/bin/
-/config/
-/crash-reports/
-/logs/
-options.txt
-/saves/
-usernamecache.json
-banned-ips.json
-banned-players.json
-eula.txt
-ops.json
-server.properties
-servers.dat
-usercache.json
-whitelist.json
-/out/
+.classpath
+.settings/
+
+## Vim ##
+### Swap ###
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]*.s[a-rt-v][a-z]
+[._]*.ss[a-gi-z]
+[._]sw[a-p]
+
+### Session ###
+Session.vim
+Sessionx.vim
+
+### Temporary Files ###
+.netrwhist
+*~
+
+### Auto-generated Tag Files ###
+tags
+
+### Undo Persistence ###
+[._]*.un~
+
+## Eclipse ##
+### Core ###
+.classpath
+.factorypath
+.project
+.settings/
+
+# Operating Systems #
+## macOS ##
+*.DS_Store
+
+# Logs #
+*.log*
+
+# Configs #
+## CSpell ##
+.cspell/
+cspell.json
+
+## Gradle ##
+addon.local.gradle
+addon.local.gradle.kts
+addon.late.local.gradle
+addon.late.local.gradle.kts
+
+## jenv ##
+.java-version
+
+# Environment #
+## General ##
+.envrc
+
+## Gradle ##
+user.properties
+
+# Cache #
+## CSpell ##
+.cspellcache
+
+# Artifacts #
+## Gradle ##
+bin/
+build/
+.gradle/
+
+# Debugging #
+## Gradle ##
+run/
+bin/
+
+# Misc. #
+# A.K.A. I don't know what they do so I'm not removing them! #
 *.iml
 *.ipr
 *.iws
-*.bat
-*.DS_Store
-!gradlew.bat
-/.vs/
+src/main/resources/mixins.*([!.]).json
+layout.json

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/IdeIntegrationModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/IdeIntegrationModule.java
@@ -44,7 +44,6 @@ public class IdeIntegrationModule implements GTNHModule {
 
     @Override
     public void apply(GTNHGradlePlugin.@NotNull GTNHExtension gtnh, @NotNull Project project) throws Throwable {
-
         project.getPluginManager()
             .apply(IdeaExtPlugin.class);
         project.getPluginManager()
@@ -58,7 +57,12 @@ public class IdeIntegrationModule implements GTNHModule {
         eclipse.getClasspath()
             .setDownloadJavadoc(true);
         final EclipseJdt ejdt = eclipse.getJdt();
-        ejdt.setTargetCompatibility(JavaVersion.VERSION_1_8);
+        JavaVersion targetCompat = JavaVersion.VERSION_1_8;
+        ejdt.setTargetCompatibility(targetCompat);
+        ejdt.getFile()
+            .withProperties(properties -> {
+                properties.setProperty("org.eclipse.jdt.core.compiler.compliance", targetCompat.toString());
+            });
         ejdt.setJavaRuntimeName("JavaSE-1.8");
         final ModernJavaSyntaxMode mode = ModernJavaSyntaxMode.fromString(gtnh.configuration.enableModernJavaSyntax);
         final int forceToolchain = gtnh.configuration.forceToolchainVersion;


### PR DESCRIPTION
This works around a bug where by some versions of JDT (notably more recent versions) will throw a fit if this value is set wrong.

For example, setting this value to `25` results in the following behavior:

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/c6403d21-d598-43c4-8f50-533502dece95" />

* A prominent warning about the mis-matched settings
* Lots of errors of various natures
* No auto-completions

Setting this value "correctly" (or at least to what JDT is expecting) corrects all the above problems.

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/ea212917-fbde-41c2-88f0-228fd4d7f5db" />