### PR TITLE
Update various mods in UpdateableConstants.java

### DIFF
--- a/src/main/java/com/gtnewhorizons/gtnhgradle/UpdateableConstants.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/UpdateableConstants.java
@@ -18,7 +18,7 @@ public class UpdateableConstants {
 
     /** Latest version of UniMixins */
     // https://github.com/LegacyModdingMC/UniMixins/releases
-    public static final String NEWEST_UNIMIXINS = "io.github.legacymoddingmc:unimixins:0.2.1";
+    public static final String NEWEST_UNIMIXINS = "io.github.legacymoddingmc:unimixins:0.3.1";
 
     /** Latest version of Jabel for modern Java support */
     public static final @NotNull String NEWEST_JABEL = "com.github.GTNewHorizons:jabel-javac-plugin:1.0.2-GTNH";
@@ -26,13 +26,13 @@ public class UpdateableConstants {
     public static final @NotNull String JABEL_STUBS = "com.github.GTNewHorizons:jabel-stubs:1.0.0";
     /** Latest version of GTNHLib for modern Java support */
     // https://github.com/GTNewHorizons/GTNHLib/releases
-    public static final @NotNull String NEWEST_GTNH_LIB = "com.github.GTNewHorizons:GTNHLib:0.9.36";
+    public static final @NotNull String NEWEST_GTNH_LIB = "com.github.GTNewHorizons:GTNHLib:0.11.0";
     /** Latest version of GTNHLib for modern Java support */
     // https://github.com/GTNewHorizons/lwjgl3ify/releases
-    public static final @NotNull String NEWEST_LWJGL3IFY = "com.github.GTNewHorizons:lwjgl3ify:3.0.15";
+    public static final @NotNull String NEWEST_LWJGL3IFY = "com.github.GTNewHorizons:lwjgl3ify:3.0.20";
     /** Latest version of GTNHLib for modern Java support */
     // https://github.com/GTNewHorizons/Hodgepodge/releases
-    public static final @NotNull String NEWEST_HODGEPODGE = "com.github.GTNewHorizons:Hodgepodge:2.7.97";
+    public static final @NotNull String NEWEST_HODGEPODGE = "com.github.GTNewHorizons:Hodgepodge:2.7.153";
     /** Latest version of LWJGL3 for modern Java support */
     // https://github.com/GTNewHorizons/lwjgl3ify/blob/master/gradle/libs.versions.toml - but check what latest
     // Minecraft uses too


### PR DESCRIPTION
Bump GTNHLib, UniMixins, Hodgepodge, and lwjgl3ify to the latest versions. Notably,
- GTNHLib now uses GTNHExtLib for providing external libraries
- UniMixins has ditched a variety of deprecated modules
- 3ify no longer crashes IDEA's linter when MCDev is enabled
- Honestly unsure what's in Hodgepodge, but 60 minor versions must have *something*