### PR TITLE
Fix crash when CHANGELOG.md is present at the root of a project

### DIFF
--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/PublishingModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/PublishingModule.java
@@ -230,14 +230,8 @@ public class PublishingModule implements GTNHModule {
     }
 
     private static String getChangelog(@NotNull Project project) throws Throwable {
-        String envPath = System.getenv("CHANGELOG_FILE");
-        if (envPath != null) {
-            Path changelogPath = Path.of(envPath);
-            if (Files.exists(changelogPath)) return Files.readString(changelogPath, StandardCharsets.UTF_8);
-        }
-
-        Path changelogPath = project.getProjectDir().toPath().resolve("CHANGELOG.md");
-        if (Files.exists(changelogPath)) return Files.readString(changelogPath, StandardCharsets.UTF_8);
+        Path changelogPath = project.getProjectDir().toPath().resolve(ObjectUtils.firstNonNull(System.getenv("CHANGELOG_FILE"), "CHANGELOG.md"));
+        if (Files.isRegularFile(changelogPath)) return Files.readString(changelogPath, StandardCharsets.UTF_8);
 
         return null;
     }

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/PublishingModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/PublishingModule.java
@@ -230,7 +230,9 @@ public class PublishingModule implements GTNHModule {
     }
 
     private static String getChangelog(@NotNull Project project) throws Throwable {
-        Path changelogPath = project.getProjectDir().toPath().resolve(ObjectUtils.firstNonNull(System.getenv("CHANGELOG_FILE"), "CHANGELOG.md"));
+        Path changelogPath = project.getProjectDir()
+            .toPath()
+            .resolve(ObjectUtils.firstNonNull(System.getenv("CHANGELOG_FILE"), "CHANGELOG.md"));
         if (Files.isRegularFile(changelogPath)) return Files.readString(changelogPath, StandardCharsets.UTF_8);
 
         return null;

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/modules/PublishingModule.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/modules/PublishingModule.java
@@ -31,6 +31,7 @@ import org.jetbrains.annotations.NotNull;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -91,7 +92,7 @@ public class PublishingModule implements GTNHModule {
             }
         }
 
-        final File changelogFile = new File(ObjectUtils.firstNonNull(System.getenv("CHANGELOG_FILE"), "CHANGELOG.md"));
+        final String changelog = getChangelog(project);
 
         // Modrinth
         final String mrToken = System.getenv("MODRINTH_TOKEN");
@@ -110,10 +111,9 @@ public class PublishingModule implements GTNHModule {
                 .set(modVersion);
             mr.getVersionType()
                 .set(modVersion.map(v -> v.endsWith("-pre") ? "beta" : "release"));
-            if (changelogFile.exists()) {
-                final String contents = Files.readString(changelogFile.toPath(), StandardCharsets.UTF_8);
+            if (changelog != null) {
                 mr.getChangelog()
-                    .set(contents);
+                    .set(changelog);
             }
             mr.getUploadFile()
                 .set(project.provider(() -> project.property("publishableObfJar")));
@@ -188,9 +188,9 @@ public class PublishingModule implements GTNHModule {
                     task.apiToken = cfToken;
                     task.disableVersionDetection();
                     task.upload(gtnh.configuration.curseForgeProjectId, obfFile, artifact -> {
-                        if (changelogFile.exists()) {
+                        if (changelog != null) {
                             artifact.changelogType = "markdown";
-                            artifact.changelog = changelogFile;
+                            artifact.changelog = changelog;
                         }
                         artifact.releaseType = modVersion.map(v -> v.endsWith("-pre") ? "beta" : "release");
                         artifact.addGameVersion(gtnh.configuration.minecraftVersion, "Forge");
@@ -227,6 +227,19 @@ public class PublishingModule implements GTNHModule {
                     .configure(task -> task.dependsOn(publishCurseforge));
             }
         }
+    }
+
+    private static String getChangelog(@NotNull Project project) throws Throwable {
+        String envPath = System.getenv("CHANGELOG_FILE");
+        if (envPath != null) {
+            Path changelogPath = Path.of(envPath);
+            if (Files.exists(changelogPath)) return Files.readString(changelogPath, StandardCharsets.UTF_8);
+        }
+
+        Path changelogPath = project.getProjectDir().toPath().resolve("CHANGELOG.md");
+        if (Files.exists(changelogPath)) return Files.readString(changelogPath, StandardCharsets.UTF_8);
+
+        return null;
     }
 
     private static final Set<String> VALID_MODRINTH_SCOPES = ImmutableSet


### PR DESCRIPTION
Crash occurs if the project is setup to publish to Modrinth and `CHANGELOG.md` is present at the root of the project. The crash occurs on any task, not just the `publish*` tasks

Fixes #63

Tested with both MR and CF publishing on an existing project.