### PR TITLE
[feat] Add a way to pass a GitHub authentication token to Blowdryer

### DIFF
--- a/src/main/java/com/gtnewhorizons/gtnhgradle/GTNHSettingsConventionPlugin.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/GTNHSettingsConventionPlugin.java
@@ -1,6 +1,7 @@
 package com.gtnewhorizons.gtnhgradle;
 
 import com.diffplug.blowdryer.BlowdryerSetup;
+import com.diffplug.blowdryer.BlowdryerSetup.GitHub;
 import com.diffplug.blowdryer.BlowdryerSetupPlugin;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
@@ -12,7 +13,8 @@ import org.gradle.toolchains.foojay.FoojayToolchainsConventionPlugin;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Applies some shared settings.gradle logic used by the GTNH mod development ecosystem.
+ * Applies some shared settings.gradle logic used by the GTNH mod development
+ * ecosystem.
  */
 @SuppressWarnings("unused") // used by Gradle
 public abstract class GTNHSettingsConventionPlugin implements Plugin<Settings> {
@@ -47,10 +49,13 @@ public abstract class GTNHSettingsConventionPlugin implements Plugin<Settings> {
                 if ("LOCAL".equals(config.blowdryerTag)) {
                     blowdryer.devLocal(".");
                 } else {
-                    blowdryer.github(
+                    final GitHub github = blowdryer.github(
                         config.exampleModGithubOwner + "/" + config.exampleModGithubProject,
                         BlowdryerSetup.GitAnchorType.TAG,
                         config.blowdryerTag);
+                    if (!config.blowdryerGitHubAuthToken.isEmpty()) {
+                        github.authToken(config.blowdryerGitHubAuthToken);
+                    }
                 }
             }
         }

--- a/src/main/java/com/gtnewhorizons/gtnhgradle/PropertiesConfiguration.java
+++ b/src/main/java/com/gtnewhorizons/gtnhgradle/PropertiesConfiguration.java
@@ -62,6 +62,18 @@ public final class PropertiesConfiguration {
             """)
     public @NotNull String blowdryerTag = UpdateableConstants.NEWEST_BLOWDRYER_TAG;
 
+    /** See annotation. */
+    @Prop(
+        name = "gtnh.settings.blowdryerGitHubAuthToken",
+        isSettings = true,
+        preferPopulated = false,
+        required = false,
+        hidden = true,
+        docComment = """
+                The authentication token to use when making requests to GitHub via the Blowdryer Gradle plugin.
+            """)
+    public @NotNull String blowdryerGitHubAuthToken = "";
+
     /** See annotation */
     @Prop(
         name = "gtnh.settings.dynamicSpotlessVersion",


### PR DESCRIPTION
## Summary ##

As said in the title, added a way to pass a GitHub Personal Access Token (PAT) to Blowdryer.

This lets developers get past GitHub's rate limiting for unauthenticated users.

I ran into this situation today while trying to test GTNewHorizons/FindIt#34.

<img width="2339" height="896" alt="image" src="https://github.com/user-attachments/assets/bd11210a-d61a-4528-9c78-4f4dc2b97999" />

As you can see, Gradle is failing because GitHub is refusing to let me access the `.importorder` file from the shared configuration file repository due to the rate limiting imposed on unauthenticated users.

From [GitHub's docs](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2026-03-10#primary-rate-limit-for-unauthenticated-users), this rate limit is 60 requests per hour for the REST API, which I think also applies to things fetched from their `raw.githubusercontent.com` domain too (though I'm not 100% sure on this).

Users who authenticate with some kind of access token are given a much higher rate limit. Blowdryer supports this via the [`authToken` API](https://javadoc.io/doc/com.diffplug/blowdryer/1.7.0/com/diffplug/blowdryer/BlowdryerSetup.GitHub.html#authToken(java.lang.String)) on the `GitHub` object.

This PR adds a new setting called `gtnh.settings.blowdryerGitHubAuthToken`. It defaults to an empty string. If it is not empty the value will be passed to the `authToken` method on the retrieved Blowdryer `GitHub` object as the value to use for authentication with GitHub's APIs.

## Testing ##

<img width="2528" height="1132" alt="image" src="https://github.com/user-attachments/assets/9331f905-b724-46b1-9557-b17419381bc0" />

## Checklist
- [-] I have tested this PR in DevEnv
  - N/A
- [-] I have tested this PR in Fullpack
  - N/A
- [+] I have tested this PR locally while building another mod
  - Tested while building GTNewHorizons/FindIt#34.
- [+] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
  - Home rolled right here in Canada!
- [-] This PR requires another PR in order to merge
  - N/A