### PR TITLE
Bump version of jvmdg to 2.0.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,7 +63,7 @@ dependencies {
     api(pluginDep("com.modrinth.minotaur", "2.8.10"))
     api(pluginDep("net.darkhax.curseforgegradle", "1.1.28"))
 
-    api(pluginDep("xyz.wagyourtail.jvmdowngrader", "1.3.5"))
+    api(pluginDep("xyz.wagyourtail.jvmdowngrader", "2.0.1"))
 
     testImplementation("org.junit.jupiter:junit-jupiter:6.0.1")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")


### PR DESCRIPTION
## Summary
Updates JVM Downgrader to version 2.0.1, which includes a fix for `switch` statements testing for instance-of being miscompiled for Java versions 21, 22, and 23 (see https://github.com/unimined/JvmDowngrader/issues/46 for details.)

PR has been tested: without this changed version of GTNHGradle applied, running code like this within a mod would cause a crash on Java 21. With this change, this code runs successfully on Java 21.
```java
Number num = 10;
switch (num) {
    case Integer i -> {
        System.out.println(i);
    }
    case Double d -> {
        System.out.println(d);
    }
    default -> {}
}
```

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack - Should be irrelevant.
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
